### PR TITLE
First bald example notebook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN jupyter nbextension enable spellchecker/main
 RUN jupyter nbextension enable toggle_all_line_numbers/main
 
 # Add notebooks to the docker image
-#COPY *.ipynb /home/jovyan/
+COPY *.ipynb /home/jovyan/
 
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+ARG JUPYTER_IMAGE=jupyter/minimal-notebook
+FROM $JUPYTER_IMAGE
+#FROM jupyter/minimal-notebook
+
+USER root
+RUN apt-get update
+RUN apt-get install -y build-essential gcc
+RUN apt-get install -y libpq-dev python-dev
+RUN apt-get install -y libhdf5-serial-dev netcdf-bin libnetcdf-dev
+RUN apt-get install -y graphviz
+
+USER jovyan
+
+
+# Add permanent pip/conda installs, data files, other user libs here
+# e.g., RUN pip install jupyter_dashboards
+COPY requirements.txt /tmp/
+RUN ls /tmp
+RUN pip install -U pip
+RUN pip install -r /tmp/requirements.txt 
+RUN python -m pip install jupyterthemes
+RUN python -m pip install --upgrade jupyterthemes
+RUN python -m pip install jupyter_contrib_nbextensions
+RUN jupyter contrib nbextension install --user
+# enable the Nbextensions
+RUN jupyter nbextension enable contrib_nbextensions_help_item/main
+RUN jupyter nbextension enable autosavetime/main
+RUN jupyter nbextension enable codefolding/main
+RUN jupyter nbextension enable code_font_size/code_font_size
+RUN jupyter nbextension enable code_prettify/code_prettify
+RUN jupyter nbextension enable collapsible_headings/main
+RUN jupyter nbextension enable comment-uncomment/main
+RUN jupyter nbextension enable gist_it/main 
+RUN jupyter nbextension enable hide_input/main 
+RUN jupyter nbextension enable spellchecker/main
+RUN jupyter nbextension enable toggle_all_line_numbers/main
+
+# Add notebooks to the docker image
+#COPY *.ipynb /home/jovyan/
+
+
+USER root
+
+# Add permanent apt-get installs and other root commands here
+# e.g., RUN apt-get install npm nodejs
+

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,7 @@
+build-essential 
+gcc
+libpq-dev 
+python-dev
+libhdf5-serial-dev 
+netcdf-bin 
+libnetcdf-dev

--- a/bald-example1.ipynb
+++ b/bald-example1.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85acc2fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from urllib.parse import urlparse\n",
+    "import bald\n",
+    "import rdflib\n",
+    "from pandas import DataFrame\n",
+    "from rdflib.plugins.sparql.processor import SPARQLResult"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0edabd79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#helper functions \n",
+    "\n",
+    "def nc2rdf(ncfilename, baseuri=None):  \n",
+    "    root_container = bald.load_netcdf(ncfilename, baseuri=baseuri)\n",
+    "    g = root_container.rdfgraph()\n",
+    "    return g\n",
+    "\n",
+    "#from https://github.com/RDFLib/sparqlwrapper/issues/125\n",
+    "def sparql_results_to_df(results: SPARQLResult) -> DataFrame:\n",
+    "    \"\"\"\n",
+    "    Export results from an rdflib SPARQL query into a `pandas.DataFrame`,\n",
+    "    using Python types. See https://github.com/RDFLib/rdflib/issues/1179.\n",
+    "    \"\"\"\n",
+    "    return DataFrame(\n",
+    "        data=([None if x is None else x.toPython() for x in row] for row in results),\n",
+    "        columns=[str(x) for x in results.vars],\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddda58a7",
+   "metadata": {},
+   "source": [
+    "## Load a single netCDF file from OpenDAP\n",
+    "\n",
+    "Using the eReefs GBR4 rivers example data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70ab28fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ncfile_gbr4_rivers=\"https://dapds00.nci.org.au/thredds/dodsC/fx3/gbr4_2.0_rivers/gbr4_rivers_simple_2022-02-03.nc\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9188bd32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_uri = \"http://localcontext/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f39a1656",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "graph = nc2rdf(ncfile_gbr4_rivers,  baseuri=base_uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c245964",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ttl = graph.serialize(format=\"turtle\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbe1be68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(ttl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d305b3b",
+   "metadata": {},
+   "source": [
+    "Now that we have the netCDF file loaded as a netCDF-LD graph, we can perform graph queries using SPARQL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73c85c26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sparql_query = \"\"\"\n",
+    "PREFIX bald: <https://www.opengis.net/def/binary-array-ld/>\n",
+    "PREFIX localcontext: <http://localcontext/> \n",
+    "\n",
+    "SELECT DISTINCT ?var ?long_name ?standard_name\n",
+    "WHERE {\n",
+    "    ?container a bald:Container .\n",
+    "    ?container bald:contains ?var .\n",
+    "    ?var localcontext:long_name ?long_name .\n",
+    "    OPTIONAL {\n",
+    "       ?var localcontext:standard_name ?standard_name .\n",
+    "    }\n",
+    "}\"\"\"\n",
+    "\n",
+    "result = graph.query(sparql_query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "855de549",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use a helper function to convert the graph result into a DataFrame for friendly rendering\n",
+    "sparql_results_to_df(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71334d35",
+   "metadata": {},
+   "source": [
+    "## Load in another netCDF file and merge the graphs\n",
+    "\n",
+    "Fetch another netCDF file (eReefs GBR1 data) and merge it with the previous netCDF file (eReefs GBR4 rivers data). \n",
+    "Note that these are from 2 different models. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fdd79b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ncfile_gbr1 = \"https://dapds00.nci.org.au/thredds/dodsC/fx3/gbr1_2.0/gbr1_simple_2022-02-05.nc\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e192204",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "base_uri = \"http://localcontext2/\"\n",
+    "graph2 = nc2rdf(ncfile_gbr1,  baseuri=base_uri)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b55fbcf",
+   "metadata": {},
+   "source": [
+    "Merge the graph using RDFLib functions. Note, we can merge any other graph in this way, e.g. other netCDF-LD graphs, wikidata graphs, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74afd90d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#merge the two graphs \n",
+    "graph = graph + graph2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d48dac3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ttl = graph.serialize(format=\"turtle\")\n",
+    "print(ttl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2aa8772d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Run the same SPARQL query but now with updated graph data\n",
+    "\n",
+    "sparql_query = \"\"\"\n",
+    "PREFIX bald: <https://www.opengis.net/def/binary-array-ld/>\n",
+    "PREFIX localcontext: <http://localcontext/> \n",
+    "PREFIX localcontext2: <http://localcontext2/> \n",
+    "\n",
+    "SELECT DISTINCT ?container ?var ?long_name ?standard_name\n",
+    "WHERE {\n",
+    "    ?container a bald:Container .\n",
+    "    ?container bald:contains ?var .\n",
+    "    ?var ?longnameProp ?long_name .\n",
+    "    OPTIONAL {\n",
+    "       ?var ?stdnameProp ?standard_name .\n",
+    "       FILTER(regex(str(?stdnameProp), \"standard_name\") )\n",
+    "    }\n",
+    "    FILTER(regex(str(?longnameProp), \"long_name\") )\n",
+    "}\n",
+    "\"\"\"\n",
+    "\n",
+    "result = graph.query(sparql_query)\n",
+    "sparql_results_to_df(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b72ce725",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#maybe look at https://stackoverflow.com/questions/39274216/visualize-an-rdflib-graph-in-python\n",
+    "'''\n",
+    "import rdflib\n",
+    "from rdflib.extras.external_graph_libs import rdflib_to_networkx_multidigraph\n",
+    "import networkx as nx\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "G = rdflib_to_networkx_multidigraph(graph)\n",
+    "# Plot Networkx instance of RDF Graph\n",
+    "pos = nx.spring_layout(G, scale=2)\n",
+    "edge_labels = nx.get_edge_attributes(G, 'r')\n",
+    "nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels)\n",
+    "nx.draw(G, with_labels=False)\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ae410b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#pydot visualise test... doesn't quite work\n",
+    "'''\n",
+    "import io\n",
+    "import pydotplus\n",
+    "from IPython.display import display, Image\n",
+    "from rdflib.tools.rdf2dot import rdf2dot\n",
+    "\n",
+    "def visualize(g):\n",
+    "    stream = io.StringIO()\n",
+    "    rdf2dot(g, stream, opts = {display})\n",
+    "    dg = pydotplus.graph_from_dot_data(stream.getvalue())\n",
+    "    png = dg.create_png()\n",
+    "    display(Image(png))\n",
+    "visualize(graph)'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8055d746",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  notebook:
+    build: .
+    image: bald-notebook
+    container_name: ${NAME}
+    volumes:
+     - ".:/home/jovyan/work"
+    ports:
+      - "${PORT:-8888}:8888"

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: bald-notebooks
+channels:
+  - defaults
+dependencies:
+  - python>=3.6
+  - pip:
+    - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+git+https://github.com/binary-array-ld/bald.git
+numpy
+h5py
+netCDF4==1.3.1
+requests
+rdflib
+jinja2
+six
+pydotplus
+graphviz
+networkx 
+pandas
+scipy 
+matplotlib 


### PR DESCRIPTION
This PR implements an example notebook that uses the `bald` library (https://github.com/binary-array-ld/bald/) to demonstrate how metadata in a netCDF file fetched remotely from OpenDAP is able to be imported as a bald/netCDF-LD (RDF) graph. Using RDF tools, the notebook demonstrates simple SPARQL queries to load into a Pandas Dataframe for viewing.

The PR includes requisite files for it to work on Binder. See this URL for a demonstation on mybinder.org 
https://mybinder.org/v2/gh/jyucsiro/bald-notebooks.git/HEAD